### PR TITLE
Add a callback that fires instantly when the button is clicked

### DIFF
--- a/Source/FaveButton.swift
+++ b/Source/FaveButton.swift
@@ -29,7 +29,11 @@ public typealias DotColors = (first: UIColor, second: UIColor)
 
 
 public protocol FaveButtonDelegate{
+    // This callback happens after the animation in the UI finishes (which takes 1 second to complete)
     func faveButton(_ faveButton: FaveButton, didSelected selected: Bool)
+
+    // The instant callback is fired immediately when the user taps the button
+    func instantCallback(_ faveButton: FaveButton, didSelected selected: Bool) 
     
     func faveButtonDotColors(_ faveButton: FaveButton) -> [DotColors]?
 }
@@ -187,6 +191,8 @@ extension FaveButton{
         guard case let delegate as FaveButtonDelegate = self.delegate else{
             return
         }
+
+        delegate.instantCallback(sender, didSelected: sender.isSelected)
         
         let delay = DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * Const.duration)) / Double(NSEC_PER_SEC)
         DispatchQueue.main.asyncAfter(deadline: delay){


### PR DESCRIPTION
The `didSelected` delegate callback happens after a one second delay so that it matches the animation, but some applications need a callback immediately when the user taps the button. This patch provides the best of both worlds.