### PR TITLE
Add a callback that fires instantly when the button is clicked

### DIFF
--- a/FaveButton.podspec
+++ b/FaveButton.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "FaveButton"
-  s.version      = "3.0.0"
+  s.version      = "3.0.1"
   s.summary      = "Twitter's heart like animated button written in Swift"
   s.license      = 'MIT'
   s.homepage     = 'https://github.com/xhamr/fave-button'

--- a/Source/FaveButton.swift
+++ b/Source/FaveButton.swift
@@ -29,7 +29,11 @@ public typealias DotColors = (first: UIColor, second: UIColor)
 
 
 public protocol FaveButtonDelegate{
+    // This callback happens after the animation in the UI finishes (which takes 1 second to complete)
     func faveButton(_ faveButton: FaveButton, didSelected selected: Bool)
+
+    // The instant callback is fired immediately when the user taps the button
+    func instantCallback(_ faveButton: FaveButton, didSelected selected: Bool) 
     
     func faveButtonDotColors(_ faveButton: FaveButton) -> [DotColors]?
 }
@@ -187,6 +191,8 @@ extension FaveButton{
         guard case let delegate as FaveButtonDelegate = self.delegate else{
             return
         }
+
+        delegate.instantCallback(sender, didSelected: sender.isSelected)
         
         let delay = DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * Const.duration)) / Double(NSEC_PER_SEC)
         DispatchQueue.main.asyncAfter(deadline: delay){

--- a/Source/FaveButton.swift
+++ b/Source/FaveButton.swift
@@ -42,6 +42,7 @@ public protocol FaveButtonDelegate{
 // MARK: Default implementation
 public extension FaveButtonDelegate{
     func faveButtonDotColors(_ faveButton: FaveButton) -> [DotColors]?{ return nil }
+    func instantCallback(_ faveButton: FaveButton, didSelected selected: Bool) { }
 }
 
 open class FaveButton: UIButton {

--- a/Source/FaveButton.swift
+++ b/Source/FaveButton.swift
@@ -187,17 +187,18 @@ extension FaveButton{
     }
     
     @objc func toggle(_ sender: FaveButton){
-        sender.isSelected = !sender.isSelected
+        let selected = !sender.isSelected
+        sender.isSelected = selected
         
         guard case let delegate as FaveButtonDelegate = self.delegate else{
             return
         }
 
-        delegate.instantCallback(sender, didSelected: sender.isSelected)
+        delegate.instantCallback(sender, didSelected: selected)
         
         let delay = DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * Const.duration)) / Double(NSEC_PER_SEC)
         DispatchQueue.main.asyncAfter(deadline: delay){
-            delegate.faveButton(sender, didSelected: sender.isSelected)
+            delegate.faveButton(sender, didSelected: selected)
         }
     }
 }


### PR DESCRIPTION
The `didSelected` delegate callback happens after a one second delay so that it matches the animation, but some applications need a callback immediately when the user taps the button. This patch provides the best of both worlds.