### PR TITLE
UIBarButtonItem Support iOS 11 and higher.

### DIFF
--- a/Source/FaveButton.swift
+++ b/Source/FaveButton.swift
@@ -64,6 +64,7 @@ open class FaveButton: UIButton {
     fileprivate var faveIconImage:UIImage?
     fileprivate var faveIcon: FaveIcon!
     fileprivate var animationsEnabled = true
+    fileprivate var didUpdateConstraints = false
     
     override open var isSelected: Bool {
         didSet{

--- a/Source/FaveButton.swift
+++ b/Source/FaveButton.swift
@@ -141,6 +141,9 @@ extension FaveButton{
         faveIcon  = createFaveIcon(faveIconImage)
         
         addActions()
+        if #available(iOS 11.0, *) {
+            self.setNeedsUpdateConstraints()
+        }
     }
     
     
@@ -231,6 +234,22 @@ extension FaveButton {
                 $0.animateIgniteShow(igniteToRadius, duration:0.4, delay: Const.collapseDuration/3.0)
                 $0.animateIgniteHide(0.7, delay: 0.2)
             }
+        }
+    }
+}
+
+// MARK: constraints
+extension FaveButton {
+    override open func updateConstraints() {
+        if didUpdateConstraints == false {
+            addFavButtonConstraints()
+        }
+        super.updateConstraints()
+    }
+    private func addFavButtonConstraints() {
+        if #available(iOS 11.0, *) {
+            self.widthAnchor.constraint(equalToConstant: frame.width).isActive = true
+            self.heightAnchor.constraint(equalToConstant: frame.height).isActive = true
         }
     }
 }


### PR DESCRIPTION
I have added constraints that fix bug, when FaveButton is untouchable when it is added to navigation bar as UIBarButtonItem(customView: FaveButton), this problem occurred on iOS 11 and higher.

```Swift
class ViewController: UIViewController, FaveButtonDelegate {
 
    let myButton = FaveButton(frame: CGRect(x: 0, y: 0, width: 24, height: 24),
                              faveIconNormal: UIImage(named: "star"))
    
    override func viewDidLoad() {
        super.viewDidLoad()
        myButton.delegate = self
        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: myButton)
    }
    
    func faveButton(_ faveButton: FaveButton, didSelected selected: Bool) {
        print("Button pressed!")
    }
}
```

![ezgif-1-f46038bad9d0](https://user-images.githubusercontent.com/6839240/55384073-66077000-5532-11e9-85b2-d07bc3d6f5c2.gif)